### PR TITLE
integrate Nix expressions for flox-examples/floxpkgs-python

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683889736,
-        "narHash": "sha256-Sxn6VNrojAl9Tu0dDy6ZqPUe0GNwRKwzHAkptXM63Wg=",
+        "lastModified": 1688654208,
+        "narHash": "sha256-GXUr6KzbiMJvalLwTv/dFNdldfqbc5yDS4uktUpdZsw=",
         "owner": "flox",
         "repo": "builtfilter",
-        "rev": "f29903b144bb20e5be80f55d3fafa323c28a2cb0",
+        "rev": "441e6eea6920581da0bb5a2924431139bf25a15a",
         "type": "github"
       },
       "original": {
@@ -23,18 +23,18 @@
     },
     "builtfilter_2": {
       "inputs": {
-        "flox-floxpkgs": [
-          "nixpkgs",
-          "flox",
-          "flox-floxpkgs"
+        "capacitor": [
+          "poetry-qiskit",
+          "flox-floxpkgs",
+          "capacitor"
         ]
       },
       "locked": {
-        "lastModified": 1683889736,
-        "narHash": "sha256-Sxn6VNrojAl9Tu0dDy6ZqPUe0GNwRKwzHAkptXM63Wg=",
+        "lastModified": 1661869301,
+        "narHash": "sha256-LcOkB1sYNCiw0rfDR09TS4v5a2p8wm4yIBPBeuZCIu4=",
         "owner": "flox",
         "repo": "builtfilter",
-        "rev": "f29903b144bb20e5be80f55d3fafa323c28a2cb0",
+        "rev": "a37cb0fb1dfb752101eb2936099530872c07c956",
         "type": "github"
       },
       "original": {
@@ -46,17 +46,18 @@
     },
     "builtfilter_3": {
       "inputs": {
-        "flox-floxpkgs": [
-          "nixpkgs",
-          "flox-floxpkgs"
+        "capacitor": [
+          "py-roberto",
+          "flox-floxpkgs",
+          "capacitor"
         ]
       },
       "locked": {
-        "lastModified": 1683889736,
-        "narHash": "sha256-Sxn6VNrojAl9Tu0dDy6ZqPUe0GNwRKwzHAkptXM63Wg=",
+        "lastModified": 1661869301,
+        "narHash": "sha256-LcOkB1sYNCiw0rfDR09TS4v5a2p8wm4yIBPBeuZCIu4=",
         "owner": "flox",
         "repo": "builtfilter",
-        "rev": "f29903b144bb20e5be80f55d3fafa323c28a2cb0",
+        "rev": "a37cb0fb1dfb752101eb2936099530872c07c956",
         "type": "github"
       },
       "original": {
@@ -111,37 +112,15 @@
     },
     "capacitor_3": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs",
-          "nixpkgs"
-        ],
+        "nixpkgs": "nixpkgs_8",
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1675629156,
-        "narHash": "sha256-55UOZa4MUTgCwyK8jrskwFLATDuMAvXyC7GGcsF45Xg=",
+        "lastModified": 1675110136,
+        "narHash": "sha256-83n/ZLBMoIkgYGy12F1hNaqMUgJsfkno5P1+sm9liOU=",
         "owner": "flox",
         "repo": "capacitor",
-        "rev": "0694a193660db2cb1a7a6e04949478b25f81d802",
-        "type": "github"
-      },
-      "original": {
-        "owner": "flox",
-        "repo": "capacitor",
-        "type": "github"
-      }
-    },
-    "capacitor_4": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_7",
-        "nixpkgs-lib": "nixpkgs-lib_4"
-      },
-      "locked": {
-        "lastModified": 1675629156,
-        "narHash": "sha256-55UOZa4MUTgCwyK8jrskwFLATDuMAvXyC7GGcsF45Xg=",
-        "owner": "flox",
-        "repo": "capacitor",
-        "rev": "0694a193660db2cb1a7a6e04949478b25f81d802",
+        "rev": "9d4b9bce0f439e01fe2c2b2a1bfe08592a6204c4",
         "type": "github"
       },
       "original": {
@@ -151,16 +130,15 @@
         "type": "github"
       }
     },
-    "capacitor_5": {
+    "capacitor_4": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs",
-          "flox",
+          "poetry-qiskit",
           "flox-floxpkgs",
           "nixpkgs",
           "nixpkgs"
         ],
-        "nixpkgs-lib": "nixpkgs-lib_5"
+        "nixpkgs-lib": "nixpkgs-lib_4"
       },
       "locked": {
         "lastModified": 1675110136,
@@ -173,6 +151,139 @@
       "original": {
         "owner": "flox",
         "repo": "capacitor",
+        "type": "github"
+      }
+    },
+    "capacitor_5": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_12",
+        "nixpkgs-lib": "nixpkgs-lib_5"
+      },
+      "locked": {
+        "lastModified": 1675110136,
+        "narHash": "sha256-83n/ZLBMoIkgYGy12F1hNaqMUgJsfkno5P1+sm9liOU=",
+        "owner": "flox",
+        "repo": "capacitor",
+        "rev": "9d4b9bce0f439e01fe2c2b2a1bfe08592a6204c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "v0",
+        "repo": "capacitor",
+        "type": "github"
+      }
+    },
+    "capacitor_6": {
+      "inputs": {
+        "nixpkgs": [
+          "py-roberto",
+          "flox-floxpkgs",
+          "nixpkgs",
+          "nixpkgs"
+        ],
+        "nixpkgs-lib": "nixpkgs-lib_6"
+      },
+      "locked": {
+        "lastModified": 1675110136,
+        "narHash": "sha256-83n/ZLBMoIkgYGy12F1hNaqMUgJsfkno5P1+sm9liOU=",
+        "owner": "flox",
+        "repo": "capacitor",
+        "rev": "9d4b9bce0f439e01fe2c2b2a1bfe08592a6204c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "repo": "capacitor",
+        "type": "github"
+      }
+    },
+    "catalog": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1665076737,
+        "narHash": "sha256-S0bD7Z434Lvm7U4VHwvmxdTMrexdr72Yk6z0ExE3j7s=",
+        "owner": "flox",
+        "repo": "floxpkgs",
+        "rev": "bd8326c2fea27d01933eacb922f5ae70f97140c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "publish",
+        "repo": "floxpkgs",
+        "type": "github"
+      }
+    },
+    "catalog_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1665076737,
+        "narHash": "sha256-S0bD7Z434Lvm7U4VHwvmxdTMrexdr72Yk6z0ExE3j7s=",
+        "owner": "flox",
+        "repo": "floxpkgs",
+        "rev": "bd8326c2fea27d01933eacb922f5ae70f97140c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "publish",
+        "repo": "floxpkgs",
+        "type": "github"
+      }
+    },
+    "commitizen-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1678272786,
+        "narHash": "sha256-ISjw9OH27XLYCYG2oLTbWN2eNQGGii92Ex7M7ynJjrE=",
+        "owner": "commitizen-tools",
+        "repo": "commitizen",
+        "rev": "fb0d1ebacb29b3ca0ea33a349dbb8064ae6c72fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "commitizen-tools",
+        "repo": "commitizen",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_3",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1688772518,
+        "narHash": "sha256-ol7gZxwvgLnxNSZwFTDJJ49xVY5teaSvF7lzlo3YQfM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "8b08e96c9af8c6e3a2b69af5a7fa168750fcf88e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "etc-profiles": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1688585987,
+        "narHash": "sha256-yFOXCPZaYkHoo5+AOL6k4cLFCFvyzy5442zZ/v3jd3w=",
+        "owner": "flox",
+        "repo": "etc-profiles",
+        "rev": "363488fbfe42825cf2efb2b4ca9d633a069d7404",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "repo": "etc-profiles",
         "type": "github"
       }
     },
@@ -224,13 +335,32 @@
         "type": "github"
       }
     },
-    "flake-utils": {
+    "flake-compat_4": {
+      "flake": false,
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
         "type": "github"
       },
       "original": {
@@ -240,12 +370,15 @@
       }
     },
     "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -269,28 +402,24 @@
         "type": "github"
       }
     },
-    "floco": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2"
-      },
+    "flake-utils_4": {
       "locked": {
-        "lastModified": 1684245865,
-        "narHash": "sha256-CJSxo7fvAAjdMaQWALyNG6LKMjOGZC/uxlbX1KuegWU=",
-        "owner": "aakropotkin",
-        "repo": "floco",
-        "rev": "e1231f054258f7d62652109725881767765b1efb",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
-        "owner": "aakropotkin",
-        "repo": "floco",
-        "rev": "e1231f054258f7d62652109725881767765b1efb",
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
-    "floco_2": {
+    "floco": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1684245865,
@@ -309,6 +438,7 @@
     },
     "flox": {
       "inputs": {
+        "crane": "crane",
         "floco": "floco",
         "flox-floxpkgs": [
           "flox-floxpkgs"
@@ -316,11 +446,11 @@
         "shellHooks": "shellHooks"
       },
       "locked": {
-        "lastModified": 1685615168,
-        "narHash": "sha256-ZIp5QbR5aiK5Nu1mfYcQEcN+Ez3vFDpzmoi2KF2hDI4=",
+        "lastModified": 1689237542,
+        "narHash": "sha256-IQkpV6NzOPd+DUYaQ56SsOJfUfVUYO3inJm6w/Uv+Vk=",
         "ref": "latest",
-        "rev": "53f93a799b548107ee5ad199c9284a1fe3b4f1fd",
-        "revCount": 491,
+        "rev": "83ab6705cb6739dd134dae4aa92d011ec07663e1",
+        "revCount": 545,
         "type": "git",
         "url": "ssh://git@github.com/flox/flox"
       },
@@ -330,20 +460,65 @@
         "url": "ssh://git@github.com/flox/flox"
       }
     },
+    "flox-bash": {
+      "inputs": {
+        "flox-floxpkgs": [
+          "poetry-qiskit",
+          "flox-floxpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1675777813,
+        "narHash": "sha256-Dmx4odN3C8GDRXoKPFYNWFq75kXqOx5uH8H/MeVv/qU=",
+        "ref": "main",
+        "rev": "d352336962766499ceb4f4eecd9252d43d1afce5",
+        "revCount": 190,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox-bash"
+      },
+      "original": {
+        "ref": "main",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox-bash"
+      }
+    },
+    "flox-bash_2": {
+      "inputs": {
+        "flox-floxpkgs": [
+          "py-roberto",
+          "flox-floxpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1678384112,
+        "narHash": "sha256-JOHaX3VP7XKnhwRc+SiGWPtirw++JCrfobF2X0Xr1PA=",
+        "ref": "main",
+        "rev": "dfb721648d4a047ae2f5afb02492ec7e025776ae",
+        "revCount": 204,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox-bash"
+      },
+      "original": {
+        "ref": "main",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox-bash"
+      }
+    },
     "flox-floxpkgs": {
       "inputs": {
         "builtfilter": "builtfilter",
         "capacitor": "capacitor",
+        "etc-profiles": "etc-profiles",
         "flox": "flox",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_6",
         "tracelinks": "tracelinks"
       },
       "locked": {
-        "lastModified": 1686002520,
-        "narHash": "sha256-zWI694mwVBt0ZZjbXU18vWRc4dKdcIeDleRw278/ZhQ=",
+        "lastModified": 1689476458,
+        "narHash": "sha256-Io5iSMisQiZ0QiyTH7wpgGnPeJp+LXYFsraLmB2RXns=",
         "owner": "flox",
         "repo": "floxpkgs",
-        "rev": "683c28b97565619c4fa76db7acfae9975589fbe9",
+        "rev": "9d01e243cde902f23e7405bde9945b7f94ab07fb",
         "type": "github"
       },
       "original": {
@@ -355,17 +530,19 @@
     "flox-floxpkgs_2": {
       "inputs": {
         "builtfilter": "builtfilter_2",
-        "capacitor": "capacitor_4",
-        "flox": "flox_3",
-        "nixpkgs": "nixpkgs_9",
+        "capacitor": "capacitor_3",
+        "catalog": "catalog",
+        "flox": "flox_2",
+        "flox-bash": "flox-bash",
+        "nixpkgs": "nixpkgs_10",
         "tracelinks": "tracelinks_2"
       },
       "locked": {
-        "lastModified": 1685613844,
-        "narHash": "sha256-n+uUuygrYpGWYZqCNz+VX82LcWd0DoSy7SN38aVuZBQ=",
+        "lastModified": 1677265441,
+        "narHash": "sha256-ZcRF5iNcEBvVUUx4ccKrJuOad+TfjVkyUlEr7v4kSNc=",
         "owner": "flox",
         "repo": "floxpkgs",
-        "rev": "2a0434dcd48b8d138f5589d283ece067e3318958",
+        "rev": "7ba1d452166da8cf409d24b30c88c815b07af0c4",
         "type": "github"
       },
       "original": {
@@ -377,25 +554,19 @@
     "flox-floxpkgs_3": {
       "inputs": {
         "builtfilter": "builtfilter_3",
-        "capacitor": [
-          "nixpkgs",
-          "capacitor"
-        ],
-        "flox": [
-          "nixpkgs",
-          "flox"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ],
+        "capacitor": "capacitor_5",
+        "catalog": "catalog_2",
+        "flox": "flox_3",
+        "flox-bash": "flox-bash_2",
+        "nixpkgs": "nixpkgs_14",
         "tracelinks": "tracelinks_3"
       },
       "locked": {
-        "lastModified": 1685839769,
-        "narHash": "sha256-FEUyFfQq2tnLrO813lS9Mkkdn8hEQY2OsXSLlkMI4T4=",
+        "lastModified": 1679569694,
+        "narHash": "sha256-BYRr0MPiamooxPKG20ed+voTfgUVStc6UmVuXBYahtk=",
         "owner": "flox",
         "repo": "floxpkgs",
-        "rev": "99ac6c684dae1f885939d6ff5e59b994ec72af0b",
+        "rev": "a0a7bbcc561115db9a7ae5bc76c4cdbf7716b8ef",
         "type": "github"
       },
       "original": {
@@ -406,45 +577,57 @@
     },
     "flox_2": {
       "inputs": {
-        "floco": "floco_2",
-        "flox-floxpkgs": "flox-floxpkgs_2",
-        "shellHooks": "shellHooks_3"
+        "flox-bash": [
+          "poetry-qiskit",
+          "flox-floxpkgs",
+          "flox-bash"
+        ],
+        "flox-floxpkgs": [
+          "poetry-qiskit",
+          "flox-floxpkgs"
+        ],
+        "shellHooks": "shellHooks_2"
       },
       "locked": {
-        "lastModified": 1685615168,
-        "narHash": "sha256-ZIp5QbR5aiK5Nu1mfYcQEcN+Ez3vFDpzmoi2KF2hDI4=",
-        "ref": "latest",
-        "rev": "53f93a799b548107ee5ad199c9284a1fe3b4f1fd",
-        "revCount": 491,
+        "lastModified": 1675765136,
+        "narHash": "sha256-/H8ygkAUn8ootNp7UsJVzeNdMs0ccMCSOQdXYkVx/gM=",
+        "ref": "main",
+        "rev": "5fb3894dba0db665a064fdd15a3052181c9affe4",
+        "revCount": 372,
         "type": "git",
         "url": "ssh://git@github.com/flox/flox"
       },
       "original": {
-        "ref": "latest",
+        "ref": "main",
         "type": "git",
         "url": "ssh://git@github.com/flox/flox"
       }
     },
     "flox_3": {
       "inputs": {
+        "commitizen-src": "commitizen-src",
+        "flox-bash": [
+          "py-roberto",
+          "flox-floxpkgs",
+          "flox-bash"
+        ],
         "flox-floxpkgs": [
-          "nixpkgs",
-          "flox",
+          "py-roberto",
           "flox-floxpkgs"
         ],
-        "shellHooks": "shellHooks_2"
+        "shellHooks": "shellHooks_3"
       },
       "locked": {
-        "lastModified": 1684338408,
-        "narHash": "sha256-9J86uTJNSFZoIlGkqglfPASE2OuWoO8Av1VTbJ8c7EA=",
-        "ref": "latest",
-        "rev": "e3f71c34046e7b71a2cf264cb09a8f95514975de",
-        "revCount": 474,
+        "lastModified": 1678377522,
+        "narHash": "sha256-Mkcp2vUAJnMpqe/ofUPJVzeLbNnWjrQUNPECXGmT4S4=",
+        "ref": "main",
+        "rev": "90fabfee9d0b19e33da6bc5a4376e382e27f658e",
+        "revCount": 404,
         "type": "git",
         "url": "ssh://git@github.com/flox/flox"
       },
       "original": {
-        "ref": "latest",
+        "ref": "main",
         "type": "git",
         "url": "ssh://git@github.com/flox/flox"
       }
@@ -475,8 +658,7 @@
     "gitignore_2": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs",
-          "flox",
+          "poetry-qiskit",
           "flox-floxpkgs",
           "flox",
           "shellHooks",
@@ -500,7 +682,8 @@
     "gitignore_3": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs",
+          "py-roberto",
+          "flox-floxpkgs",
           "flox",
           "shellHooks",
           "nixpkgs"
@@ -540,11 +723,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684754342,
-        "narHash": "sha256-plGnjnbnPLoZCTdQX21oT7xliQhFtgcWlkuDHgtEb1o=",
+        "lastModified": 1687661089,
+        "narHash": "sha256-RhF9PiNfOQpm/Q2BR+2305KDR9FCXD6QJizbZ5vxVvQ=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "7084250df3d7f9735087d3234407f3c1fc2400e3",
+        "rev": "f742512ccc99e6ac457d6d4ddce78f283c4bbfde",
         "type": "github"
       },
       "original": {
@@ -556,11 +739,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1685840432,
-        "narHash": "sha256-VJIbiKsY7Xy4E4WcgwUt/UiwYDmN5BAk8tngAjcWsqY=",
+        "lastModified": 1689469483,
+        "narHash": "sha256-2SBhY7rZQ/iNCxe04Eqxlz9YK9KgbaTMBssq3/BgdWY=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "961e99baaaa57f5f7042fe7ce089a88786c839f4",
+        "rev": "02fea408f27186f139153e1ae88f8ab2abd9c22c",
         "type": "github"
       },
       "original": {
@@ -571,11 +754,11 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1685561605,
-        "narHash": "sha256-LqEu1IWP8UWKxwwrpPtp1/p+JRCaUI0hl8e4hht5YdI=",
+        "lastModified": 1689469483,
+        "narHash": "sha256-2SBhY7rZQ/iNCxe04Eqxlz9YK9KgbaTMBssq3/BgdWY=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "75aeea15ee4971c52c56bbbee84066e74d53d858",
+        "rev": "02fea408f27186f139153e1ae88f8ab2abd9c22c",
         "type": "github"
       },
       "original": {
@@ -586,11 +769,11 @@
     },
     "nixpkgs-lib_3": {
       "locked": {
-        "lastModified": 1685561605,
-        "narHash": "sha256-LqEu1IWP8UWKxwwrpPtp1/p+JRCaUI0hl8e4hht5YdI=",
+        "lastModified": 1676767889,
+        "narHash": "sha256-VjGXT6nZv8KrmrIUkAJr8MjDLJ/mRgWZqCC9mq5J6Gg=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "75aeea15ee4971c52c56bbbee84066e74d53d858",
+        "rev": "710d8816159a542ed0b1dcaf47748e2813af53f5",
         "type": "github"
       },
       "original": {
@@ -601,11 +784,11 @@
     },
     "nixpkgs-lib_4": {
       "locked": {
-        "lastModified": 1685561605,
-        "narHash": "sha256-LqEu1IWP8UWKxwwrpPtp1/p+JRCaUI0hl8e4hht5YdI=",
+        "lastModified": 1674953599,
+        "narHash": "sha256-DlAzFbth2P6Hp1M7smDd1apa2dJdxw3FeaWpl03LWeU=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "75aeea15ee4971c52c56bbbee84066e74d53d858",
+        "rev": "a6486be6c11c609cd60c01a427279e8a80a025fa",
         "type": "github"
       },
       "original": {
@@ -616,11 +799,26 @@
     },
     "nixpkgs-lib_5": {
       "locked": {
-        "lastModified": 1681001314,
-        "narHash": "sha256-5sDnCLdrKZqxLPK4KA8+f4A3YKO/u6ElpMILvX0g72c=",
+        "lastModified": 1679187309,
+        "narHash": "sha256-H8udmkg5wppL11d/05MMzOMryiYvc403axjDNZy1/TQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "367c0e1086a4eb4502b24d872cea2c7acdd557f4",
+        "rev": "44214417fe4595438b31bdb9469be92536a61455",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_6": {
+      "locked": {
+        "lastModified": 1679187309,
+        "narHash": "sha256-H8udmkg5wppL11d/05MMzOMryiYvc403axjDNZy1/TQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "44214417fe4595438b31bdb9469be92536a61455",
         "type": "github"
       },
       "original": {
@@ -631,27 +829,27 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1678872516,
-        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1684754342,
-        "narHash": "sha256-plGnjnbnPLoZCTdQX21oT7xliQhFtgcWlkuDHgtEb1o=",
+        "lastModified": 1687661089,
+        "narHash": "sha256-RhF9PiNfOQpm/Q2BR+2305KDR9FCXD6QJizbZ5vxVvQ=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "7084250df3d7f9735087d3234407f3c1fc2400e3",
+        "rev": "f742512ccc99e6ac457d6d4ddce78f283c4bbfde",
         "type": "github"
       },
       "original": {
@@ -663,11 +861,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1678872516,
-        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "lastModified": 1673800717,
+        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
         "type": "github"
       },
       "original": {
@@ -679,11 +877,11 @@
     },
     "nixpkgs-stable_4": {
       "locked": {
-        "lastModified": 1679262748,
-        "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
+        "lastModified": 1671983799,
+        "narHash": "sha256-Z2Ro6hFPZHkBqkVXY5/aBUzxi5xizQGvuHQ9+T5B/ks=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "60c1d71f2ba4c80178ec84523c2ca0801522e0a6",
+        "rev": "fad51abd42ca17a60fc1d4cb9382e2d79ae31836",
         "type": "github"
       },
       "original": {
@@ -695,11 +893,11 @@
     },
     "nixpkgs-stable_5": {
       "locked": {
-        "lastModified": 1678872516,
-        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "lastModified": 1673800717,
+        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
         "type": "github"
       },
       "original": {
@@ -711,11 +909,11 @@
     },
     "nixpkgs-stable_6": {
       "locked": {
-        "lastModified": 1684754342,
-        "narHash": "sha256-plGnjnbnPLoZCTdQX21oT7xliQhFtgcWlkuDHgtEb1o=",
+        "lastModified": 1676973346,
+        "narHash": "sha256-rft8oGMocTAhUVqG3LW6I8K/Fo9ICGmNjRqaWTJwav0=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "7084250df3d7f9735087d3234407f3c1fc2400e3",
+        "rev": "d0d55259081f0b97c828f38559cad899d351cad1",
         "type": "github"
       },
       "original": {
@@ -727,11 +925,11 @@
     },
     "nixpkgs-staging": {
       "locked": {
-        "lastModified": 1684754342,
-        "narHash": "sha256-plGnjnbnPLoZCTdQX21oT7xliQhFtgcWlkuDHgtEb1o=",
+        "lastModified": 1688231357,
+        "narHash": "sha256-ZOn16X5jZ6X5ror58gOJAxPfFLAQhZJ6nOUeS4tfFwo=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "7084250df3d7f9735087d3234407f3c1fc2400e3",
+        "rev": "645ff62e09d294a30de823cb568e9c6d68e92606",
         "type": "github"
       },
       "original": {
@@ -743,11 +941,11 @@
     },
     "nixpkgs-staging_2": {
       "locked": {
-        "lastModified": 1683408522,
-        "narHash": "sha256-9kcPh6Uxo17a3kK3XCHhcWiV1Yu1kYj22RHiymUhMkU=",
+        "lastModified": 1674459583,
+        "narHash": "sha256-L0UZl/u2H3HGsrhN+by42c5kNYeKtdmJiPzIRvEVeiM=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "897876e4c484f1e8f92009fd11b7d988a121a4e7",
+        "rev": "1b1f50645af2a70dc93eae18bfd88d330bfbcf7f",
         "type": "github"
       },
       "original": {
@@ -759,11 +957,11 @@
     },
     "nixpkgs-staging_3": {
       "locked": {
-        "lastModified": 1684754342,
-        "narHash": "sha256-plGnjnbnPLoZCTdQX21oT7xliQhFtgcWlkuDHgtEb1o=",
+        "lastModified": 1678654296,
+        "narHash": "sha256-aVfw3ThpY7vkUeF1rFy10NAkpKDS2imj3IakrzT0Occ=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "7084250df3d7f9735087d3234407f3c1fc2400e3",
+        "rev": "5a1dc8acd977ff3dccd1328b7c4a6995429a656b",
         "type": "github"
       },
       "original": {
@@ -775,11 +973,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1684754342,
-        "narHash": "sha256-plGnjnbnPLoZCTdQX21oT7xliQhFtgcWlkuDHgtEb1o=",
+        "lastModified": 1688231357,
+        "narHash": "sha256-ZOn16X5jZ6X5ror58gOJAxPfFLAQhZJ6nOUeS4tfFwo=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "7084250df3d7f9735087d3234407f3c1fc2400e3",
+        "rev": "645ff62e09d294a30de823cb568e9c6d68e92606",
         "type": "github"
       },
       "original": {
@@ -791,11 +989,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1684139381,
-        "narHash": "sha256-YPLMeYE+UzxxP0qbkBzv3RBDvyGR5I4d7v2n8dI3+fY=",
+        "lastModified": 1674641431,
+        "narHash": "sha256-qfo19qVZBP4qn5M5gXc/h1MDgAtPA5VxJm9s8RUAkVk=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "17a689596b72d1906883484838eb1aaf51ab8001",
+        "rev": "9b97ad7b4330aacda9b2343396eb3df8a853b4fc",
         "type": "github"
       },
       "original": {
@@ -807,11 +1005,11 @@
     },
     "nixpkgs-unstable_3": {
       "locked": {
-        "lastModified": 1684754342,
-        "narHash": "sha256-plGnjnbnPLoZCTdQX21oT7xliQhFtgcWlkuDHgtEb1o=",
+        "lastModified": 1679262748,
+        "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "7084250df3d7f9735087d3234407f3c1fc2400e3",
+        "rev": "60c1d71f2ba4c80178ec84523c2ca0801522e0a6",
         "type": "github"
       },
       "original": {
@@ -822,81 +1020,38 @@
       }
     },
     "nixpkgs_10": {
-      "locked": {
-        "lastModified": 1681303793,
-        "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "fe2ecaf706a5907b5e54d979fbde4924d84b65fc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1674236650,
-        "narHash": "sha256-B4GKL1YdJnII6DQNNJ4wDW1ySJVx2suB1h/v4Ql8J0Q=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "cfb43ad7b941d9c3606fb35d91228da7ebddbfc5",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1681303793,
-        "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "fe2ecaf706a5907b5e54d979fbde4924d84b65fc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
       "inputs": {
-        "capacitor": "capacitor_2",
+        "capacitor": "capacitor_4",
         "flox": [
+          "poetry-qiskit",
           "flox-floxpkgs",
           "flox"
         ],
+        "flox-bash": [
+          "poetry-qiskit",
+          "flox-floxpkgs",
+          "flox-bash"
+        ],
         "flox-floxpkgs": [
+          "poetry-qiskit",
           "flox-floxpkgs"
         ],
-        "nixpkgs": [
-          "flox-floxpkgs",
-          "nixpkgs",
-          "nixpkgs-stable"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable_2",
-        "nixpkgs-staging": "nixpkgs-staging",
-        "nixpkgs-unstable": "nixpkgs-unstable",
-        "nixpkgs__flox__aarch64-darwin": "nixpkgs__flox__aarch64-darwin",
-        "nixpkgs__flox__aarch64-linux": "nixpkgs__flox__aarch64-linux",
-        "nixpkgs__flox__i686-linux": "nixpkgs__flox__i686-linux",
-        "nixpkgs__flox__x86_64-darwin": "nixpkgs__flox__x86_64-darwin",
-        "nixpkgs__flox__x86_64-linux": "nixpkgs__flox__x86_64-linux"
+        "nixpkgs": "nixpkgs_11",
+        "nixpkgs-stable": "nixpkgs-stable_4",
+        "nixpkgs-staging": "nixpkgs-staging_2",
+        "nixpkgs-unstable": "nixpkgs-unstable_2",
+        "nixpkgs__flox__aarch64-darwin": "nixpkgs__flox__aarch64-darwin_2",
+        "nixpkgs__flox__aarch64-linux": "nixpkgs__flox__aarch64-linux_2",
+        "nixpkgs__flox__i686-linux": "nixpkgs__flox__i686-linux_2",
+        "nixpkgs__flox__x86_64-darwin": "nixpkgs__flox__x86_64-darwin_2",
+        "nixpkgs__flox__x86_64-linux": "nixpkgs__flox__x86_64-linux_2"
       },
       "locked": {
-        "lastModified": 1685839832,
-        "narHash": "sha256-RTAWQ/lRZPOpHwxYRLQqva5aTw5wuBC/FsE4Qvof3nY=",
+        "lastModified": 1675117426,
+        "narHash": "sha256-zrSqcqWaFbJXnUKgFlIrNg6/73DAgdWr75UoxjTDrRo=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "03eb5c0a1e88c2b185f756e25fecd6c6253877e1",
+        "rev": "bc44d6d77530ff0f5d7cdf28b4d8feb37bc8af70",
         "type": "github"
       },
       "original": {
@@ -905,12 +1060,72 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_11": {
+      "locked": {
+        "lastModified": 1674459583,
+        "narHash": "sha256-L0UZl/u2H3HGsrhN+by42c5kNYeKtdmJiPzIRvEVeiM=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "1b1f50645af2a70dc93eae18bfd88d330bfbcf7f",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs-stable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_12": {
+      "locked": {
+        "lastModified": 1676973346,
+        "narHash": "sha256-rft8oGMocTAhUVqG3LW6I8K/Fo9ICGmNjRqaWTJwav0=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "d0d55259081f0b97c828f38559cad899d351cad1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "stable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_13": {
+      "locked": {
+        "lastModified": 1671271357,
+        "narHash": "sha256-xRJdLbWK4v2SewmSStYrcLa0YGJpleufl44A19XSW8k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "40f79f003b6377bd2f4ed4027dde1f8f922995dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_14": {
       "inputs": {
-        "capacitor": "capacitor_3",
-        "flox": "flox_2",
-        "flox-floxpkgs": "flox-floxpkgs_3",
+        "capacitor": "capacitor_6",
+        "flox": [
+          "py-roberto",
+          "flox-floxpkgs",
+          "flox"
+        ],
+        "flox-bash": [
+          "py-roberto",
+          "flox-floxpkgs",
+          "flox-bash"
+        ],
+        "flox-floxpkgs": [
+          "py-roberto",
+          "flox-floxpkgs"
+        ],
         "nixpkgs": [
+          "py-roberto",
+          "flox-floxpkgs",
           "nixpkgs",
           "nixpkgs-stable"
         ],
@@ -924,11 +1139,11 @@
         "nixpkgs__flox__x86_64-linux": "nixpkgs__flox__x86_64-linux_3"
       },
       "locked": {
-        "lastModified": 1685839832,
-        "narHash": "sha256-RTAWQ/lRZPOpHwxYRLQqva5aTw5wuBC/FsE4Qvof3nY=",
+        "lastModified": 1679425590,
+        "narHash": "sha256-+VjJ8P/k63M6OKD51Ccd3sSkkBHE7BPXVJ7fw9YZkpo=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "03eb5c0a1e88c2b185f756e25fecd6c6253877e1",
+        "rev": "8caf06dfde8665904ad00df28092f1fa0bad54b4",
         "type": "github"
       },
       "original": {
@@ -937,7 +1152,37 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1687977148,
+        "narHash": "sha256-gUcXiU2GgjYIc65GOIemdBJZ+lkQxuyIh7OkR9j0gCo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "60a783e00517fce85c42c8c53fe0ed05ded5b2a4",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1688221086,
+        "narHash": "sha256-cdW6qUL71cNWhHCpMPOJjlw0wzSRP0pVlRn2vqX/VVg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cd99c2b3c9f160cd004318e0697f90bbd5960825",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1674236650,
         "narHash": "sha256-B4GKL1YdJnII6DQNNJ4wDW1ySJVx2suB1h/v4Ql8J0Q=",
@@ -951,13 +1196,77 @@
         "type": "indirect"
       }
     },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1685866647,
+        "narHash": "sha256-4jKguNHY/edLYImB+uL8jKPL/vpfOvMmSlLAGfxSrnY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a53a3bec10deef6e1cc1caba5bc60f53b959b1e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
+      "inputs": {
+        "capacitor": "capacitor_2",
+        "flox": [
+          "flox-floxpkgs",
+          "flox"
+        ],
+        "flox-floxpkgs": [
+          "flox-floxpkgs"
+        ],
+        "nixpkgs": "nixpkgs_7",
+        "nixpkgs-stable": "nixpkgs-stable_2",
+        "nixpkgs-staging": "nixpkgs-staging",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "nixpkgs__flox__aarch64-darwin": "nixpkgs__flox__aarch64-darwin",
+        "nixpkgs__flox__aarch64-linux": "nixpkgs__flox__aarch64-linux",
+        "nixpkgs__flox__i686-linux": "nixpkgs__flox__i686-linux",
+        "nixpkgs__flox__x86_64-darwin": "nixpkgs__flox__x86_64-darwin",
+        "nixpkgs__flox__x86_64-linux": "nixpkgs__flox__x86_64-linux"
+      },
+      "locked": {
+        "lastModified": 1689476418,
+        "narHash": "sha256-xcpOhnSKazYFneCUVw0PZQN9CvzNWh+wYnXV4ErmQXM=",
+        "owner": "flox",
+        "repo": "nixpkgs-flox",
+        "rev": "ade75fc1f697f7ffc0b1ba48dd177f659fd135bd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "repo": "nixpkgs-flox",
+        "type": "github"
+      }
+    },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1679262748,
-        "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
+        "lastModified": 1687661089,
+        "narHash": "sha256-RhF9PiNfOQpm/Q2BR+2305KDR9FCXD6QJizbZ5vxVvQ=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "60c1d71f2ba4c80178ec84523c2ca0801522e0a6",
+        "rev": "f742512ccc99e6ac457d6d4ddce78f283c4bbfde",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs-stable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_8": {
+      "locked": {
+        "lastModified": 1674459583,
+        "narHash": "sha256-L0UZl/u2H3HGsrhN+by42c5kNYeKtdmJiPzIRvEVeiM=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "1b1f50645af2a70dc93eae18bfd88d330bfbcf7f",
         "type": "github"
       },
       "original": {
@@ -967,13 +1276,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_9": {
       "locked": {
-        "lastModified": 1681303793,
-        "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
+        "lastModified": 1671271357,
+        "narHash": "sha256-xRJdLbWK4v2SewmSStYrcLa0YGJpleufl44A19XSW8k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fe2ecaf706a5907b5e54d979fbde4924d84b65fc",
+        "rev": "40f79f003b6377bd2f4ed4027dde1f8f922995dd",
         "type": "github"
       },
       "original": {
@@ -983,59 +1292,15 @@
         "type": "github"
       }
     },
-    "nixpkgs_9": {
-      "inputs": {
-        "capacitor": "capacitor_5",
-        "flox": [
-          "nixpkgs",
-          "flox",
-          "flox-floxpkgs",
-          "flox"
-        ],
-        "flox-floxpkgs": [
-          "nixpkgs",
-          "flox",
-          "flox-floxpkgs"
-        ],
-        "nixpkgs": [
-          "nixpkgs",
-          "flox",
-          "flox-floxpkgs",
-          "nixpkgs",
-          "nixpkgs-stable"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable_4",
-        "nixpkgs-staging": "nixpkgs-staging_2",
-        "nixpkgs-unstable": "nixpkgs-unstable_2",
-        "nixpkgs__flox__aarch64-darwin": "nixpkgs__flox__aarch64-darwin_2",
-        "nixpkgs__flox__aarch64-linux": "nixpkgs__flox__aarch64-linux_2",
-        "nixpkgs__flox__i686-linux": "nixpkgs__flox__i686-linux_2",
-        "nixpkgs__flox__x86_64-darwin": "nixpkgs__flox__x86_64-darwin_2",
-        "nixpkgs__flox__x86_64-linux": "nixpkgs__flox__x86_64-linux_2"
-      },
-      "locked": {
-        "lastModified": 1684261611,
-        "narHash": "sha256-x3tzeIyPOSvV+m9s5dsdF+br0c3GSiPqQeXAuouNW/I=",
-        "owner": "flox",
-        "repo": "nixpkgs-flox",
-        "rev": "91fac666cf98d81798249b37ea7a79128df7b731",
-        "type": "github"
-      },
-      "original": {
-        "owner": "flox",
-        "repo": "nixpkgs-flox",
-        "type": "github"
-      }
-    },
     "nixpkgs__flox__aarch64-darwin": {
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1685839397,
-        "narHash": "sha256-tnONvFxMpI+jwmtOBidAJnS43xdVv5xYb/e/nWrBpTU=",
+        "lastModified": 1689475913,
+        "narHash": "sha256-uhf6Fwi8YUb7pziTSaNjIyadL95dmHhMI/g9n4PSzD0=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "70c8b1abfe9b9e89b283d562a68631d63c80e9f1",
+        "rev": "ea655498baadd6094205f017b1a8d8b9d1e23c61",
         "type": "github"
       },
       "original": {
@@ -1050,11 +1315,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1684261401,
-        "narHash": "sha256-OSOSo+xC8wODgd1QJaWOnEnYQcI9P9W8Cs7dNZyoyDI=",
+        "lastModified": 1675107732,
+        "narHash": "sha256-jKctlxsXMgxzSV7THZcN4s1oIDf39saRCoMQ7DBIWTo=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "ecf3fb534e7356ee575d4540b3eab50550970db4",
+        "rev": "170f500c77984dda06846d47efe44990023d30b1",
         "type": "github"
       },
       "original": {
@@ -1069,11 +1334,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1685839397,
-        "narHash": "sha256-tnONvFxMpI+jwmtOBidAJnS43xdVv5xYb/e/nWrBpTU=",
+        "lastModified": 1679425359,
+        "narHash": "sha256-u6a4pHkBL3gQS2hX/8F7HYFFqanoujnIOkrFX0TeQNo=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "70c8b1abfe9b9e89b283d562a68631d63c80e9f1",
+        "rev": "7e780979a917e8c9442be0c444284b2cb9d56d43",
         "type": "github"
       },
       "original": {
@@ -1088,11 +1353,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1685839359,
-        "narHash": "sha256-XDz7W+J9cmaqEIBpA4R1hTFVC6gU4cB6DuUK2HMkvBc=",
+        "lastModified": 1689475872,
+        "narHash": "sha256-T+077uBXugrXR0IEpWzdWOAoyPVt3UaH68McJKbIcx8=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "5818b58bc6509d6f3b951601b7ac666e363ee4af",
+        "rev": "7f1d24cfcc2574667bbd1b91b7a19c2cab099b88",
         "type": "github"
       },
       "original": {
@@ -1107,11 +1372,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1684261380,
-        "narHash": "sha256-/WNnEEuPlk0EmagNIsNx89Rde8q8FYx25zIN6PuUJT8=",
+        "lastModified": 1675107716,
+        "narHash": "sha256-9vzgSX6ESPsqMPaSSMSWJqsFOq6AvDQgL84tDFCiv+A=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "93e7d09b709aa79cc7ff1e2907dd4c56e4054f2c",
+        "rev": "9c56e6ff1169d268d45b0071982d4094f0db953c",
         "type": "github"
       },
       "original": {
@@ -1126,11 +1391,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1685839359,
-        "narHash": "sha256-XDz7W+J9cmaqEIBpA4R1hTFVC6gU4cB6DuUK2HMkvBc=",
+        "lastModified": 1679411716,
+        "narHash": "sha256-XfIpNAciF72byX4b+USIE5qrFVlODTqyp1bCcENU1Wg=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "5818b58bc6509d6f3b951601b7ac666e363ee4af",
+        "rev": "d81303f302954cdff91a045819c20d3ae1a797bb",
         "type": "github"
       },
       "original": {
@@ -1145,11 +1410,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1685839747,
-        "narHash": "sha256-lYt8GcYNVkoDDZGM0Sz1DN2veRlKrb9GbS+mb5aSxco=",
+        "lastModified": 1689476327,
+        "narHash": "sha256-/hcIDHwzAdnBj8qONetnlf6jzEd7Hh2YgXOSU3MQkYc=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "9c5ffd59b75ed17d4e8551d579d3df665bb3c2fd",
+        "rev": "26392cd1d599906c681067cce729303e33502135",
         "type": "github"
       },
       "original": {
@@ -1164,11 +1429,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1684261523,
-        "narHash": "sha256-QzBj5gtnLavuODRLr4P7+zSiXP06m/8hvgj6bFwkEEA=",
+        "lastModified": 1675107834,
+        "narHash": "sha256-wPiaSntujDHzJgTDb1d3Uv1pVePyW1kQNG05M9gOUjM=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "e20fe347aab23f5dfae38c159af2277b0b30ad74",
+        "rev": "ea7a0479a45597c6c5c97d73e8cc76057c9124d0",
         "type": "github"
       },
       "original": {
@@ -1183,11 +1448,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1685839747,
-        "narHash": "sha256-lYt8GcYNVkoDDZGM0Sz1DN2veRlKrb9GbS+mb5aSxco=",
+        "lastModified": 1679411918,
+        "narHash": "sha256-QJxDXWkxNQpTOwoX8PfLBPjeI5FrSmSZavWkDfywDlE=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "9c5ffd59b75ed17d4e8551d579d3df665bb3c2fd",
+        "rev": "50973361a36e36aeea9ef4dbe018dffc97f80334",
         "type": "github"
       },
       "original": {
@@ -1202,11 +1467,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1685839730,
-        "narHash": "sha256-RbLL6E8ZwcNgZdRJDkzW/pa27d87NItB5yqEbOWwCMM=",
+        "lastModified": 1689476308,
+        "narHash": "sha256-KVQdpLoCiB45iGcOJx0P2izck/6XJS3xXRgU0KKFK/U=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "773ca8c0a9fea331f9326608a89c14b5cd50e78f",
+        "rev": "32c687ffdab8541f740c99e6d5c25c658a5c9da9",
         "type": "github"
       },
       "original": {
@@ -1221,11 +1486,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1684249749,
-        "narHash": "sha256-I0dHf0vClpC0xLGju41W2keLkwbqBGQmHLaHSqjAHaU=",
+        "lastModified": 1675107826,
+        "narHash": "sha256-7QrCrtw36223WtDHPYsvCN331VS7xGfOFGWaRhLRHGc=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "370ed1a0363ccb70e6881f918b10cd0e302afa1f",
+        "rev": "5f174893aef5ab34f6cd1b87eeffa80b8bf81fe6",
         "type": "github"
       },
       "original": {
@@ -1240,11 +1505,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1685839730,
-        "narHash": "sha256-RbLL6E8ZwcNgZdRJDkzW/pa27d87NItB5yqEbOWwCMM=",
+        "lastModified": 1679425495,
+        "narHash": "sha256-0BqOrBVjO0Eme7l46rZRhr2Hg2KUberTXhCI1aTViLk=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "773ca8c0a9fea331f9326608a89c14b5cd50e78f",
+        "rev": "5f34546a6f4a5dc93886385520e9b7c2e96e6a7b",
         "type": "github"
       },
       "original": {
@@ -1259,11 +1524,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1685839663,
-        "narHash": "sha256-Co1e9gCYTnboVE+h8/OKsD0ntX1IRWcS9ZOdlfnYxX0=",
+        "lastModified": 1689476266,
+        "narHash": "sha256-cEh6FF7y9UuADRxCWYmdodZjq8Ot39Tc/ZVTbbVN63o=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "72a60d4ce8d0dd5cb0111234fa7c5f8760cc3d1b",
+        "rev": "8039597542a7007c2a30c9b0fbb8c7c15096b1a8",
         "type": "github"
       },
       "original": {
@@ -1278,11 +1543,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1684261497,
-        "narHash": "sha256-7BOL1QKjDqe/THzXE+q9u59T9PsCBfqUEZCsFKh9t8M=",
+        "lastModified": 1673555550,
+        "narHash": "sha256-11+5aS8Q15cz6U4cgsWf/gA4QFSo5cdsbqc5J2RKQJE=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "87ab69a422ae6aa153c6d4cb6278517e43f28bf5",
+        "rev": "d38ddf9c20aa652cf66069c71c85c9cb2b49461f",
         "type": "github"
       },
       "original": {
@@ -1297,11 +1562,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1685839663,
-        "narHash": "sha256-Co1e9gCYTnboVE+h8/OKsD0ntX1IRWcS9ZOdlfnYxX0=",
+        "lastModified": 1679411880,
+        "narHash": "sha256-dEpKZqad0Tm3eEJHkdumm7KXjWK7IxwiZXoGliqPJ2k=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "72a60d4ce8d0dd5cb0111234fa7c5f8760cc3d1b",
+        "rev": "a75cc182848bacca527ac6f81d974e5357d1f570",
         "type": "github"
       },
       "original": {
@@ -1312,27 +1577,93 @@
         "type": "github"
       }
     },
+    "poetry-qiskit": {
+      "inputs": {
+        "flox-floxpkgs": "flox-floxpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1681337515,
+        "narHash": "sha256-/4h633FYdKR5B614zPcrlz6/rpVgGtjLGDeK2xm0Ho0=",
+        "owner": "flox-examples",
+        "repo": "poetry-qiskit",
+        "rev": "e648af4bd9a025ed4172600faf42bdb34185a8c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox-examples",
+        "repo": "poetry-qiskit",
+        "type": "github"
+      }
+    },
+    "py-roberto": {
+      "inputs": {
+        "flox-floxpkgs": "flox-floxpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1689530100,
+        "narHash": "sha256-sqSw9CpzOj7PxmPyHqnlBN8RC7LkcvGeVyCkVb0i1QM=",
+        "owner": "flox-examples",
+        "repo": "py-roberto",
+        "rev": "4d349d4fb1852756d264afe0d3900d2bffbbf3fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox-examples",
+        "repo": "py-roberto",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flox-floxpkgs": "flox-floxpkgs",
         "hello-python": "hello-python",
-        "nixpkgs": "nixpkgs_5"
+        "poetry-qiskit": "poetry-qiskit",
+        "py-roberto": "py-roberto"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flox-floxpkgs",
+          "flox",
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "flox-floxpkgs",
+          "flox",
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688351637,
+        "narHash": "sha256-CLTufJ29VxNOIZ8UTg0lepsn3X03AmopmaLTTeHDCL4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "f9b92316727af9e6c7fee4a761242f7f46880329",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "shellHooks": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_5",
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1685361114,
-        "narHash": "sha256-4RjrlSb+OO+e1nzTExKW58o3WRwVGpXwj97iCta8aj4=",
+        "lastModified": 1688596063,
+        "narHash": "sha256-9t7RxBiKWHygsqXtiNATTJt4lim/oSYZV3RG8OjDDng=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ca2fdbf3edda2a38140184da6381d49f8206eaf4",
+        "rev": "c8d18ba345730019c3faf412c96a045ade171895",
         "type": "github"
       },
       "original": {
@@ -1343,18 +1674,18 @@
     },
     "shellHooks_2": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
+        "flake-compat": "flake-compat_3",
+        "flake-utils": "flake-utils_3",
         "gitignore": "gitignore_2",
-        "nixpkgs": "nixpkgs_8",
+        "nixpkgs": "nixpkgs_9",
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1684195081,
-        "narHash": "sha256-IKnQUSBhQTChFERxW2AzuauVpY1HRgeVzAjNMAA4B6I=",
+        "lastModified": 1675337566,
+        "narHash": "sha256-jmLBTQcs1jFOn8h1Q5b5XwPfYgFOtcZ3+mU9KvfC6Js=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "96eabec58248ed8f4b0ad59e7ce9398018684fdc",
+        "rev": "5668d079583a5b594cb4e0cc0e6d84f1b93da7ae",
         "type": "github"
       },
       "original": {
@@ -1365,23 +1696,53 @@
     },
     "shellHooks_3": {
       "inputs": {
-        "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_3",
+        "flake-compat": "flake-compat_4",
+        "flake-utils": "flake-utils_4",
         "gitignore": "gitignore_3",
-        "nixpkgs": "nixpkgs_10",
+        "nixpkgs": "nixpkgs_13",
         "nixpkgs-stable": "nixpkgs-stable_5"
       },
       "locked": {
-        "lastModified": 1685361114,
-        "narHash": "sha256-4RjrlSb+OO+e1nzTExKW58o3WRwVGpXwj97iCta8aj4=",
+        "lastModified": 1677832802,
+        "narHash": "sha256-XQf+k6mBYTiQUjWRf/0fozy5InAs03O1b30adCpWeXs=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ca2fdbf3edda2a38140184da6381d49f8206eaf4",
+        "rev": "382bee738397ca005206eefa36922cc10df8a21c",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     },
@@ -1409,17 +1770,16 @@
     "tracelinks_2": {
       "inputs": {
         "flox-floxpkgs": [
-          "nixpkgs",
-          "flox",
+          "poetry-qiskit",
           "flox-floxpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1683889723,
-        "narHash": "sha256-h7LMr8tgu4RJecin4oEO50WoTU0rTomAW9+7AJroX0Y=",
+        "lastModified": 1674847293,
+        "narHash": "sha256-wPirp+8gIUpoAgE8zoXZalAJzCzcdDHKLEPOapJUtfs=",
         "ref": "main",
-        "rev": "e05561bdd0ed9d10c66e35a1d8e66defab949534",
-        "revCount": 11,
+        "rev": "46108503f52bc2fcc948abb9b00fc65a13e5f5bd",
+        "revCount": 9,
         "type": "git",
         "url": "ssh://git@github.com/flox/tracelinks"
       },
@@ -1432,16 +1792,16 @@
     "tracelinks_3": {
       "inputs": {
         "flox-floxpkgs": [
-          "nixpkgs",
+          "py-roberto",
           "flox-floxpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1683889723,
-        "narHash": "sha256-h7LMr8tgu4RJecin4oEO50WoTU0rTomAW9+7AJroX0Y=",
+        "lastModified": 1674847293,
+        "narHash": "sha256-wPirp+8gIUpoAgE8zoXZalAJzCzcdDHKLEPOapJUtfs=",
         "ref": "main",
-        "rev": "e05561bdd0ed9d10c66e35a1d8e66defab949534",
-        "revCount": 11,
+        "rev": "46108503f52bc2fcc948abb9b00fc65a13e5f5bd",
+        "revCount": 9,
         "type": "git",
         "url": "ssh://git@github.com/flox/tracelinks"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -1,23 +1,103 @@
 {
-  
+  description = "Floxpkgs/Project Template";
+  inputs.flox-floxpkgs.url = "github:flox/floxpkgs";
 
   # Declaration of external resources
   # =================================
   inputs.hello-python.url = "github:flox-examples/hello-python";
   inputs.hello-python.inputs.flox-floxpkgs.follows = "/";
+  inputs.poetry-qiskit.url = "github:flox-examples/poetry-qiskit";
+  # inputs.poetry-qiskit.inputs.flox-floxpkgs.follows = "/";
+  inputs.py-roberto.url = "github:flox-examples/py-roberto";
+  # inputs.py-roberto.inputs.flox-floxpkgs.follows = "/";
 
   # =================================
 
+  outputs = args @ {flox-floxpkgs, ...}:
+    flox-floxpkgs.project args (context: {
+      # explicit package definitions
+      # the format is equivalent to package definitions in
+      # `./pkgs/my-pkg/default.nix`
+      packages = {
+        # explicit packages allow re-exports of single packages
+        # from package sets that can't be accessed by all users of this project
+        #
+        # Note: re-exporting generally provides less guarantees
+        #       than importing a package set in terms of composability.
+        #       `config.projects` should be used preferably, if possible.
+        #
+        # Note: if re-export comes from a capacitated flake,
+        #       use `context.capacitated` over `context.inputs`
+        #       to ensure coherent dependencies.
+        /*
+        ext-pkg = context: context.capacitated.my-project.packages.ext-pkg;
+        */
+      };
 
-  description = "Floxpkgs/Project Template";
-  nixConfig.bash-prompt = "[flox] \\[\\033[38;5;172m\\]λ \\[\\033[0m\\]";
+      config = {
+        # by default all packages defined in this flake will be buildable on
+        # the four most common platforms.
+        # `config.settings` allows additional systems to be configured
+        # by overriding the default set
+        /*
+        systems = [
+          "aarch64-darwin"
+          "aarch64-linux"
+          "x86_64-darwin"
+          "x86_64-linux"
+        ];
+        */
 
-  # Template DO NOT EDIT
-  # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  # TODO: injected by the cli, or used via registry?
-  inputs.flox-floxpkgs.url = "github:flox/floxpkgs";
-  inputs.nixpkgs.url = "github:flox/nixpkgs-flox";
-  inputs.nixpkgs.inputs.floxpkgs.follows = "flox-floxpkgs";
-  outputs = args @ {flox-floxpkgs, ...}: flox-floxpkgs.capacitor args (import ./flox.nix);
-  # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        nixpkgs-config = {
+          # Unfree licenses are disallowed by default
+          # but can be enabled on a per-project basis.
+          #
+          # If an unfree package is imported by one of your packages,
+          # trying to build the package will raise an error like:
+          #
+          #   Package 'slack-4.29.149' in /nix/store/... has an unfree license
+          #   ('unfree'), refusing to evaluate.
+          #
+          # The configuration below shows how to permit the usage of "slack"
+          # or other tools that run into this problem.
+          #
+          # Note: the configuration only applies to the current project
+          #       and overrides the config in projects.
+          #       It also affects only packages when accessed through the
+          #       `context` - either in a package definition
+          #       or `context.nixpkgs.slack`.
+          /*
+          allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
+            "slack"
+          ];
+          */
+
+          # `config.projects` can be used to compose capacitated  package sets.
+          # All packages defined in the imported projects will be merged
+          # and become available in the `context` of this flake.
+          #
+          # Note: composing package sets may require rebuilding some packages
+          #       as some dependency versions may differ
+          #       from one package set to another.
+          #       composing such package sets ensures a single coherent set.
+          projects = {
+            /*
+            inherit (context.capacitated) my-project;
+            */
+          };
+
+          # If a package is already defined by an imported project
+          # (see `config.projects`) an error will be thrown asking to rename
+          # the local package or ensure that it is compatible
+          # with the existing package.
+          # If you choose to attest its compatibility,
+          # add the name of the package here, as instructed at build time.
+          checkedExtensions = [
+            /*
+            "some-package"
+            */
+          ];
+        };
+      };
+    });
 }

--- a/pkgs/autoray/default.nix
+++ b/pkgs/autoray/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.autoray

--- a/pkgs/cmaes/default.nix
+++ b/pkgs/cmaes/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.cmaes

--- a/pkgs/cotengra/default.nix
+++ b/pkgs/cotengra/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.cotengra

--- a/pkgs/cryptography/default.nix
+++ b/pkgs/cryptography/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.cryptography

--- a/pkgs/cvxopt/default.nix
+++ b/pkgs/cvxopt/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.cvxopt

--- a/pkgs/filelock/default.nix
+++ b/pkgs/filelock/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.filelock

--- a/pkgs/gym/default.nix
+++ b/pkgs/gym/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.py-roberto.packages.gym

--- a/pkgs/matplotlib/default.nix
+++ b/pkgs/matplotlib/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.matplotlib

--- a/pkgs/nevergrad/default.nix
+++ b/pkgs/nevergrad/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.nevergrad

--- a/pkgs/optuna/default.nix
+++ b/pkgs/optuna/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.optuna

--- a/pkgs/pathspec/default.nix
+++ b/pkgs/pathspec/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.pathspec

--- a/pkgs/pyscf/default.nix
+++ b/pkgs/pyscf/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.pyscf

--- a/pkgs/qdldl/default.nix
+++ b/pkgs/qdldl/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.qdldl

--- a/pkgs/qiskit-aer/default.nix
+++ b/pkgs/qiskit-aer/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.qiskit-aer

--- a/pkgs/qiskit-terra/default.nix
+++ b/pkgs/qiskit-terra/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.qiskit-terra

--- a/pkgs/ruff/default.nix
+++ b/pkgs/ruff/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.ruff

--- a/pkgs/rustworkx/default.nix
+++ b/pkgs/rustworkx/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.rustworkx

--- a/pkgs/symengine/default.nix
+++ b/pkgs/symengine/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.symengine

--- a/pkgs/tweedledum/default.nix
+++ b/pkgs/tweedledum/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.tweedledum

--- a/pkgs/virtualenv/default.nix
+++ b/pkgs/virtualenv/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.poetry-qiskit.packages.virtualenv


### PR DESCRIPTION
The github:flox-examples/floxpkgs-python repository was a temporary catalog created to serve a catalog of builds for [discourse issue 665](https://discourse.floxdev.com/t/questions-around-using-this-with-python-packages/665/16)

Converted top-level flake.nix to the latest template version and added inputs for the following repositories:

- github:flox-examples/py-roberto
- github:flox-examples/poetry-qiskit